### PR TITLE
Experimental support for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.so
 *.dylib
 
+# Build output files
+out/
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/eastlondoner/kportal/cmd/manager
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest
+FROM alpine:latest
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/eastlondoner/kportal/manager .
 ENTRYPOINT ["./manager"]

--- a/bin/configure-kportal-as-dns
+++ b/bin/configure-kportal-as-dns
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errtrace -o errexit -o nounset
+shopt -s inherit_errexit
+
+[[ -n "${TRACE:-}" ]] && set -o xtrace
+
+declare errmsg="ERROR (${0##*/})":
+trap 'echo >&2 $errmsg trap on error \(rc=${PIPESTATUS[@]}\) near line $LINENO' ERR
+
+usage() {
+  echo "configure-kportal-as-dns <KPORTAL_IP>
+
+  Sets up the system this is run on to point *.cluster.local DNS-lookups
+  to kportal.
+"
+}
+
+readonly DOMAINS=(cluster.local neo4j.io)
+
+main() {
+  if [[ "$@" == "" ]]; then
+    usage
+    exit 1
+  fi
+
+  local kportal_ip="$1"
+
+
+  if is_network_manager_system; then
+    install_on_network_manager_system "$kportal_ip"
+  fi
+}
+
+# Does the system quack like one that's running dmasq under Ubuntu's Network Manager?
+is_network_manager_system() {
+  [ -d /etc/NetworkManager/dnsmasq.d ]
+}
+
+install_on_network_manager_system() {
+  local ip="$1"
+  local config="/etc/NetworkManager/dnsmasq.d/kportal.conf"
+
+  local content=""
+  for domain in $DOMAINS; do
+    content="${content}server=/${domain}/${ip}
+"
+  done
+
+  local current="$(<"${config}")
+" # don't ask
+
+  if [[ "${current}" != "${content}" ]]; then
+    echo "${content}" | sudo tee "${config}" > /dev/null
+    sudo service network-manager restart
+  fi
+}
+
+main "$@"

--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -44,7 +44,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, 1053))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 	defer close(StartTestManager(mgr, g))
 

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -12,7 +12,7 @@ type DNSNameserver struct {
 	handler dns.Handler
 }
 
-func NewNameserver(myIP string) *DNSNameserver {
+func NewNameserver(myIP string, bindPort int) *DNSNameserver {
 
 	myDomains := new(gdns.Hostitem)
 
@@ -25,16 +25,16 @@ func NewNameserver(myIP string) *DNSNameserver {
 		Listen: []gdns.Addr{
 			gdns.Addr{
 				Host:    "0.0.0.0",
-				Port:    1053,
+				Port:    bindPort,
 				Network: "udp",
 			},
 			gdns.Addr{
 				Host:    "0.0.0.0",
-				Port:    1053,
+				Port:    bindPort,
 				Network: "tcp",
 			},
 		},
-		ForwardRules:[]gdns.Rule{},
+		ForwardRules: []gdns.Rule{},
 		DefaultUpstream: []gdns.Addr{
 			gdns.Addr{
 				Host:    "1.1.1.1",
@@ -47,8 +47,8 @@ func NewNameserver(myIP string) *DNSNameserver {
 				Network: "tcp",
 			},
 		},
-		Hosts: myDomains,
-		Timeout:30,
+		Hosts:   myDomains,
+		Timeout: 30,
 	}
 
 	h := gdns.NewDNSHandler(&config)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/config/config.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/config/config.go
@@ -70,14 +70,16 @@ func GetConfig() (*rest.Config, error) {
 		return c, nil
 	}
 	// If no in-cluster config, try the default location in the user's home directory
+	path := "none"
 	if usr, err := user.Current(); err == nil {
+		path = filepath.Join(usr.HomeDir, ".kube", "config")
 		if c, err := clientcmd.BuildConfigFromFlags(
 			"", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
 			return c, nil
 		}
 	}
 
-	return nil, fmt.Errorf("could not locate a kubeconfig")
+	return nil, fmt.Errorf("could not locate a kubeconfig: %s", path)
 }
 
 // GetConfigOrDie creates a *rest.Config for talking to a Kubernetes apiserver.


### PR DESCRIPTION
Linux fundamentally relies on resolv.conf(5) for DNS things.
It lets you specify a list of DNS servers, and linux tools will
try them in order, waiting for each one to time out before trying
the next one. resolve.conf only allows specifying IPs, so any
DNS server serving resolve.conf must bind to port 53.

Because of the restrictions in resolve.conf, many linux distros, like
Ubuntu, ship with dnsmasq as an on-board DNS server. resolv.conf is
configured to use 127.0.0.1 as the DNS server, and the distro has
dnsmasq serve DNS queries there. dnsmasq allows much more flexible
configuration, such as pointing specific domains to specific DNSes.

Hence:
- dnsmasq is nice, but not always available
- for broad linux support, kportal needs to bind to port 53
- kportal can't bind to 127.0.0.1:53 on ubuntu, because its in use

This commit makes three changes:
1) It moves kportal to run inside a docker container. This gives
   kportal a dedicated locally routable IP, and the ability to bind
   low-level ports on that IP; notably port 53, but also all ports it
   needs to proxy.

2) It introduces a shell script to configure ubuntu-based systems to
   forward specific domains to the IP docker assigned the kportal
   container.

3) It modifies kportal to use `hostname -i` to determine which IP to
   reply with for DNS lookups; inside docker, that will be the bridge
   network IP, so reachable by the host and other containers. When ran
   on the host, it should resolve (works on my machine!) to 127.0.0.1